### PR TITLE
Replaces context.ancestorWidgetOfExactType with context.findAncestorW…

### DIFF
--- a/lib/src/animation_configuration.dart
+++ b/lib/src/animation_configuration.dart
@@ -158,7 +158,6 @@ class AnimationConfiguration extends InheritedWidget {
           .toList();
 
   static AnimationConfiguration of(BuildContext context) {
-    return context.ancestorWidgetOfExactType(AnimationConfiguration)
-        as AnimationConfiguration;
+    return context.findAncestorWidgetOfExactType<AnimationConfiguration>();
   }
 }

--- a/lib/src/animation_limiter.dart
+++ b/lib/src/animation_limiter.dart
@@ -72,7 +72,6 @@ class _AnimationLimiterProvider extends InheritedWidget {
   }
 
   static _AnimationLimiterProvider of(BuildContext context) {
-    return context.ancestorWidgetOfExactType(_AnimationLimiterProvider)
-        as _AnimationLimiterProvider;
+    return context.findAncestorWidgetOfExactType<_AnimationLimiterProvider>();
   }
 }


### PR DESCRIPTION
…idgetOfExactType

Fixes compile errors due to method being removed from Flutter